### PR TITLE
Round string before format and ajust zeros after the decimal

### DIFF
--- a/jquery.price_format.js
+++ b/jquery.price_format.js
@@ -154,7 +154,7 @@
 			function price_it ()
 			{
 				var str = obj.val();
-				var price = price_format(str);
+        var price = price_format(str);
 				if (str != price) obj.val(price);
 			}
 
@@ -196,6 +196,13 @@
 			// If value has content
 			if ($(this).val().length>0)
 			{
+				var str = obj.val();
+        var decimalRegExp = new RegExp("[^.]\\d*$");
+        if (decimal = str.match(decimalRegExp)) {
+          // round str and ajust zeros after the decimal
+          if (decimal[0].length != centsLimit) str = (Math.round(parseFloat(str) * Math.pow(10, centsLimit)) / Math.pow(10, centsLimit)).toFixed(centsLimit).toString();
+          obj.val(str);
+        }
 				price_it();
 				clear_prefix();
 			}


### PR DESCRIPTION
Hi, 

I made this pull request after some troubles with Rails applications, in Rails some fields use format like '54.0' with centsLimit = 2 and using priceFormat, value was formatted to 'R$ 540,00', the correct is 'R$ 54,00'. 
Other issue is values with decimal is greater than centsLimit ex:
$('field').priceFormat({
  centsLimit = 2
});
input value 31.3182
formatted value will be 'R$ 3.131,82' the correct way is 'R$ 31,32'