### PR TITLE
Add ability to remove price format events

### DIFF
--- a/jquery.price_format.js
+++ b/jquery.price_format.js
@@ -256,7 +256,7 @@
     /******************
     * Unmask Function *
     *******************/
-    jQuery.fn.unmask = function(){
+    $.fn.unmask = function(){
 
         var field = $(this).val();
         var result = "";


### PR DESCRIPTION
Events are namespaced now and you can detach them using $.fn.unpriceFormat
