### PR TITLE
Enables more functional keys

### DIFF
--- a/Prototype_Price_Format.js
+++ b/Prototype_Price_Format.js
@@ -55,16 +55,10 @@ keyCheck : function(e) {
 		functional = true;
 	if (code == 13)
 		functional = true;
-	if (code == 46)
-		functional = true;
-	if (code == 35)
-		functional = true;
-	if (code == 36)
-		functional = true;
-	if (code == 37)
-		functional = true;
-	if (code == 39)
-		functional = true;
+	if (code >= 16 && code <= 20) functional = true;
+	if (code == 27) functional = true;
+	if (code >= 33 && code <= 40) functional = true;
+	if (code >= 44 && code <= 46) functional = true;
 	if (this.allowNegative && (code == 189 || code == 109))
 		functional = true; // dash as well
 

--- a/jquery.price_format.js
+++ b/jquery.price_format.js
@@ -156,10 +156,13 @@
 				if (code ==  8) functional = true;
 				if (code ==  9) functional = true;
 				if (code == 13) functional = true;
-				if (code == 46) functional = true;
-				if (code == 37) functional = true;
-				if (code == 39) functional = true;
 				if (allowNegative && (code == 189 || code == 109)) functional = true; // dash as well
+
+                                //Allow Home, End, Shift, Caps Lock, Esc
+                                if (code >= 16 && code <= 20) functional = true;
+                                if (code == 27) functional = true;
+                                if (code >= 33 && code <= 40) functional = true;
+                                if (code >= 44 && code <= 46) functional = true;
 
 				if (!functional)
 				{


### PR DESCRIPTION
The following keys were ignored previously.  Since they are functional keys, not characters, there's no reason for them to be disabled.  This pull request is for enabling them.

shift	 16
ctrl	 17
alt	 18
pause/break	 19
caps lock	 20
escape	 27
page up	 33
page down	 34
end	 35
home	 36
up arrow	 38
down arrow	 40
print screen   44
insert	 45

Keycode map reference: http://www.cambiaresearch.com/articles/15/javascript-char-codes-key-codes