### PR TITLE
Added a trigger when price is updated

### DIFF
--- a/jquery.price_format.js
+++ b/jquery.price_format.js
@@ -64,10 +64,12 @@
 
 			function set(nvalue)
 			{
-				if(obj.is('input'))
+				if(obj.is('input')){
 					obj.val(nvalue);
-				else
+					obj.trigger('pricechange');
+				}else{
 					obj.html(nvalue);
+				}
 			}
 			
 			function get()


### PR DESCRIPTION
This is really useful for doing calculations as the user enters a price. Listening to the 'input' trigger didn't work because it's triggered before the price is updated, so using this 'pricechange' trigger you can get the new updated value and do calculations.